### PR TITLE
Fix -Werror failure due to deprecated Qt functions

### DIFF
--- a/src/canorus.cpp
+++ b/src/canorus.cpp
@@ -417,11 +417,7 @@ void CACanorus::connectSlotsByName(QObject* pOS, const QObject* pOR)
     Q_ASSERT(mo);
     const QObjectList list = pOS->findChildren<QObject*>(QString());
     for (int i = 0; i < mo->methodCount(); ++i) {
-#if QT_VERSION >= 0x050000
         const char* slot = mo->method(i).methodSignature().data();
-#else
-        const char* slot = mo->method(i).signature();
-#endif
         Q_ASSERT(slot);
         if (slot[0] != 'o' || slot[1] != 'n' || slot[2] != '_')
             continue;
@@ -443,11 +439,7 @@ void CACanorus::connectSlotsByName(QObject* pOS, const QObject* pOR)
                     if (smo->method(k).methodType() != QMetaMethod::Signal)
                         continue;
 
-#if QT_VERSION >= 0x050000
                     if (!qstrncmp(smo->method(k).methodSignature().data(), slot + len + 4, slotlen)) {
-#else
-                    if (!qstrncmp(smo->method(k).signature(), slot + len + 4, slotlen)) {
-#endif
                         sigIndex = k;
                         break;
                     }

--- a/src/layout/drawablemark.cpp
+++ b/src/layout/drawablemark.cpp
@@ -58,7 +58,11 @@ CADrawableMark::CADrawableMark(CAMark* mark, CADrawableContext* dContext, double
         font.setPixelSize(qRound(DEFAULT_TEXT_SIZE));
         QFontMetrics fm(font);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int textWidth = fm.horizontalAdvance(static_cast<CAText*>(this->mark())->text());
+#else
         int textWidth = fm.width(static_cast<CAText*>(this->mark())->text());
+#endif
         setWidth(textWidth < 11 ? 11 : textWidth); // set minimum text width at least 11 points
         setHeight(qRound(DEFAULT_TEXT_SIZE));
         break;
@@ -68,7 +72,11 @@ CADrawableMark::CADrawableMark(CAMark* mark, CADrawableContext* dContext, double
         font.setPixelSize(qRound(DEFAULT_TEXT_SIZE));
         QFontMetrics fm(font);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int textWidth = fm.horizontalAdvance(static_cast<CABookMark*>(this->mark())->text());
+#else
         int textWidth = fm.width(static_cast<CABookMark*>(this->mark())->text());
+#endif
         setWidth(DEFAULT_PIXMAP_SIZE + textWidth);
         setHeight(qRound(DEFAULT_TEXT_SIZE));
         _pixmap = new QPixmap("images:mark/bookmark.svg");
@@ -79,7 +87,11 @@ CADrawableMark::CADrawableMark(CAMark* mark, CADrawableContext* dContext, double
         font.setPixelSize(qRound(DEFAULT_TEXT_SIZE));
         QFontMetrics fm(font);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int textWidth = fm.horizontalAdvance(static_cast<CADynamic*>(this->mark())->text());
+#else
         int textWidth = fm.width(static_cast<CADynamic*>(this->mark())->text());
+#endif
         setWidth(textWidth < 11 ? 11 : textWidth); // set minimum text width at least 11 points
         setHeight(qRound(DEFAULT_TEXT_SIZE));
         break;
@@ -108,7 +120,11 @@ CADrawableMark::CADrawableMark(CAMark* mark, CADrawableContext* dContext, double
         QFontMetrics fm(font);
 
         _pixmap = new QPixmap("images:mark/instrumentchange.svg");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        int textWidth = fm.horizontalAdvance(CAMidiDevice::instrumentName(static_cast<CAInstrumentChange*>(this->mark())->instrument()));
+#else
         int textWidth = fm.width(CAMidiDevice::instrumentName(static_cast<CAInstrumentChange*>(this->mark())->instrument()));
+#endif
         setWidth(DEFAULT_PIXMAP_SIZE + textWidth); // set minimum text width at least 11 points
         setHeight(qRound(DEFAULT_TEXT_SIZE));
         break;
@@ -138,7 +154,11 @@ CADrawableMark::CADrawableMark(CAMark* mark, CADrawableContext* dContext, double
         QFontMetrics fm(font);
 
         QString text = fingerListToString(static_cast<CAFingering*>(mark)->fingerList());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+        setWidth(fm.horizontalAdvance(text)); // set minimum text width at least 11 points
+#else
         setWidth(fm.width(text)); // set minimum text width at least 11 points
+#endif
         setHeight(11);
 
         break;

--- a/src/layout/drawablestaff.cpp
+++ b/src/layout/drawablestaff.cpp
@@ -231,7 +231,7 @@ bool CADrawableStaff::xDrawableBarlineLessThan(const CADrawableBarline* a, const
 */
 CABarline* CADrawableStaff::getBarline(double x)
 {
-    QList<CADrawableBarline*>::const_iterator it = qLowerBound(_drawableBarlineList.constBegin(), _drawableBarlineList.constEnd(), x, CADrawableStaff::xDrawableBarlineLessThan);
+    QList<CADrawableBarline*>::const_iterator it = std::lower_bound(_drawableBarlineList.constBegin(), _drawableBarlineList.constEnd(), x, CADrawableStaff::xDrawableBarlineLessThan);
     if (it != _drawableBarlineList.constBegin()) {
         it--;
     }

--- a/src/layout/drawablesyllable.cpp
+++ b/src/layout/drawablesyllable.cpp
@@ -24,7 +24,11 @@ CADrawableSyllable::CADrawableSyllable(CASyllable* s, CADrawableLyricsContext* c
     QFont font("Century Schoolbook L");
     font.setPixelSize(qRound(DEFAULT_TEXT_SIZE));
     QFontMetrics fm(font);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    int textWidth = fm.horizontalAdvance(textToDrawableText(s->text()));
+#else
     int textWidth = fm.width(textToDrawableText(s->text()));
+#endif
     setWidth(textWidth < 11 ? 11 : textWidth); // set minimum text width at least 11 points
     setHeight(qRound(DEFAULT_TEXT_SIZE));
 }
@@ -44,7 +48,11 @@ void CADrawableSyllable::draw(QPainter* p, const CADrawSettings s)
     p->setFont(font);
     p->drawText(s.x, s.y + qRound(height() * s.z), textToDrawableText(syllable()->text()));
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    int textWidth = QFontMetrics(font).horizontalAdvance(textToDrawableText(syllable()->text()));
+#else
     int textWidth = QFontMetrics(font).width(textToDrawableText(syllable()->text()));
+#endif
     if (syllable()->hyphenStart() && (width() * s.z - textWidth) > qRound(DEFAULT_DASH_LENGTH * s.z)) {
         p->drawLine(qRound(s.x + width() * s.z * 0.5 + 0.5 * textWidth - 0.5 * s.z * DEFAULT_DASH_LENGTH), s.y + qRound(height() * s.z * 0.7),
             qRound(s.x + width() * s.z * 0.5 + 0.5 * textWidth + 0.5 * s.z * DEFAULT_DASH_LENGTH), s.y + qRound(height() * s.z * 0.7));

--- a/src/score/playablelength.cpp
+++ b/src/score/playablelength.cpp
@@ -213,7 +213,11 @@ QList<CAPlayableLength> CAPlayableLength::timeLengthToPlayableLengthList(int t, 
     int i, j;
     if (!longNotesFirst)
         for (i = 0, j = pl.size() - 1; i < j; i++, j--)
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+            pl.swapItemsAt(i, j);
+#else
             pl.swap(i, j);
+#endif
     return pl;
 }
 

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -234,7 +234,7 @@ void CASettingsDialog::on_uiDocumentsDirectoryRevert_clicked(bool)
 
 void CASettingsDialog::on_uiBackgroundColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiBackgroundColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiBackgroundColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiBackgroundColor->setPalette(QPalette(c));
         uiPreviewScoreView->setBackgroundColor(c);
@@ -251,7 +251,7 @@ void CASettingsDialog::on_uiBackgroundRevert_clicked(bool)
 
 void CASettingsDialog::on_uiForegroundColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiForegroundColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiForegroundColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiForegroundColor->setPalette(QPalette(c));
         uiPreviewScoreView->setForegroundColor(c);
@@ -268,7 +268,7 @@ void CASettingsDialog::on_uiForegroundRevert_clicked(bool)
 
 void CASettingsDialog::on_uiSelectionColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiSelectionColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiSelectionColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiSelectionColor->setPalette(QPalette(c));
         uiPreviewScoreView->setSelectionColor(c);
@@ -285,7 +285,7 @@ void CASettingsDialog::on_uiSelectionRevert_clicked(bool)
 
 void CASettingsDialog::on_uiSelectionAreaColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiSelectionAreaColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiSelectionAreaColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiSelectionAreaColor->setPalette(QPalette(c));
         uiPreviewScoreView->setSelectionAreaColor(c);
@@ -302,7 +302,7 @@ void CASettingsDialog::on_uiSelectionAreaRevert_clicked(bool)
 
 void CASettingsDialog::on_uiSelectedContextColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiSelectedContextColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiSelectedContextColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiSelectedContextColor->setPalette(QPalette(c));
         uiPreviewScoreView->setSelectedContextColor(c);
@@ -319,7 +319,7 @@ void CASettingsDialog::on_uiSelectedContextRevert_clicked(bool)
 
 void CASettingsDialog::on_uiHiddenElementsColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiHiddenElementsColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiHiddenElementsColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiHiddenElementsColor->setPalette(QPalette(c));
         uiPreviewScoreView->setHiddenElementsColor(c);
@@ -336,7 +336,7 @@ void CASettingsDialog::on_uiHiddenElementsRevert_clicked(bool)
 
 void CASettingsDialog::on_uiDisabledElementsColor_clicked(bool)
 {
-    QColor c = QColor::fromRgba(QColorDialog::getRgba(uiDisabledElementsColor->palette().color(QPalette::Window).rgba(), nullptr, this));
+    QColor c = QColorDialog::getColor(uiDisabledElementsColor->palette().color(QPalette::Window), this, QString(), QColorDialog::ShowAlphaChannel);
     if (c.isValid()) {
         uiDisabledElementsColor->setPalette(QPalette(c));
         uiPreviewScoreView->setDisabledElementsColor(c);

--- a/src/widgets/actionseditor.cpp
+++ b/src/widgets/actionseditor.cpp
@@ -69,14 +69,11 @@ QList <QKeySequence> ActionsEditor::stringToShortcuts(QString shortcuts) {
 
 	for (int n=0; n < l.count(); n++) {
 		//qDebug("%s", l[n].toUtf8().data());
-#if QT_VERSION >= 0x040300
-		// Qt 4.3 and 4.4 (at least on linux) seems to have a problem when using Traditional Chinese
+
+		// Qt (at least on linux) seems to have a problem when using Traditional Chinese
 		// QKeysequence deletes the arrow key names from the shortcut
 		// so this is a work-around.
 		QString s = l[n].simplified();
-#else
-		QString s = QKeySequence( l[n].simplified() );
-#endif
 		
 		//Work-around for Simplified-Chinese
 		s.replace( QString::fromUtf8("左"), "Left");
@@ -103,13 +100,8 @@ CAActionsEditor::CAActionsEditor(QWidget* parent, Qt::WindowFlags f)
     actionsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     actionsTable->verticalHeader()->hide();
 
-#if QT_VERSION >= 0x050000
     actionsTable->horizontalHeader()->setSectionResizeMode(COL_COMMAND, QHeaderView::Stretch);
     actionsTable->horizontalHeader()->setSectionResizeMode(COL_DESCRIPTION, QHeaderView::Stretch);
-#else
-    actionsTable->horizontalHeader()->setResizeMode(COL_COMMAND, QHeaderView::Stretch);
-    actionsTable->horizontalHeader()->setResizeMode(COL_DESCRIPTION, QHeaderView::Stretch);
-#endif
 
     actionsTable->setAlternatingRowColors(true);
     //#if USE_SHORTCUTGETTER
@@ -722,7 +714,7 @@ void CAActionsEditor::changeEvent(QEvent* e)
 static QString keyToString(int k)
 {
     if (k == Qt::Key_Shift || k == Qt::Key_Control || k == Qt::Key_Meta || k == Qt::Key_Alt || k == Qt::Key_AltGr)
-        return QString::null;
+        return QString();
 
     return QKeySequence(k).toString();
 }

--- a/src/widgets/scoreview.cpp
+++ b/src/widgets/scoreview.cpp
@@ -1911,7 +1911,7 @@ double CAScoreView::timeToCoordsSimpleVersion(int time)
     QList<CAVoice*> voiceList = _sheet->voiceList();
     for (int i = 0; i < voiceList.size(); i++) {
         // get the element still smaller or equal, but nearest to time
-        QList<CAMusElement*>::const_iterator it = qLowerBound(voiceList[i]->musElementList().constBegin(), voiceList[i]->musElementList().constEnd(), time, CAScoreView::musElementTimeLessThan);
+        QList<CAMusElement*>::const_iterator it = std::lower_bound(voiceList[i]->musElementList().constBegin(), voiceList[i]->musElementList().constEnd(), time, CAScoreView::musElementTimeLessThan);
         if (it != voiceList[i]->musElementList().constEnd()) {
             if (_mapDrawable.contains(*it)) {
                 CADrawableMusElement* dElt = static_cast<CADrawableMusElement*>(_mapDrawable.values(*it).last());
@@ -1939,7 +1939,7 @@ double CAScoreView::timeToCoords(int time)
     QList<CAVoice*> voiceList = _sheet->voiceList();
     for (int i = 0; i < voiceList.size(); i++) {
         // get the element still smaller or equal, but nearest to time
-        QList<CAMusElement*>::const_iterator it = qLowerBound(voiceList[i]->musElementList().constBegin(), voiceList[i]->musElementList().constEnd(), time, CAScoreView::musElementTimeLessThan);
+        QList<CAMusElement*>::const_iterator it = std::lower_bound(voiceList[i]->musElementList().constBegin(), voiceList[i]->musElementList().constEnd(), time, CAScoreView::musElementTimeLessThan);
         if (it != voiceList[i]->musElementList().constEnd()) {
             if (_mapDrawable.contains(*it)) {
                 CADrawableMusElement* dElt = static_cast<CADrawableMusElement*>(_mapDrawable.values(*it).last());
@@ -1952,7 +1952,7 @@ double CAScoreView::timeToCoords(int time)
         }
 
         // and for the right element
-        it = qUpperBound(voiceList[i]->musElementList().constBegin(), voiceList[i]->musElementList().constEnd(), time, CAScoreView::timeMusElementLessThan);
+        it = std::upper_bound(voiceList[i]->musElementList().constBegin(), voiceList[i]->musElementList().constEnd(), time, CAScoreView::timeMusElementLessThan);
         if (it != voiceList[i]->musElementList().constEnd()) {
             if (_mapDrawable.contains(*it)) {
                 CADrawableMusElement* dElt = static_cast<CADrawableMusElement*>(_mapDrawable.values(*it).first());

--- a/src/widgets/toolbutton.cpp
+++ b/src/widgets/toolbutton.cpp
@@ -11,6 +11,7 @@
 #include <QDesktopWidget>
 #include <QMainWindow>
 #include <QMouseEvent>
+#include <QScreen>
 #include <QStyle>
 #include <QStyleOptionToolButton>
 
@@ -135,7 +136,7 @@ QPoint CAToolButton::calculateTopLeft(QSize size)
     QToolBar* toolBar = dynamic_cast<QToolBar*>(parent());
     if (mainWin() && toolBar) {
         QPoint topLeft = mapToGlobal(QPoint(0, 0)); // get the absolute coordinates of top-left corner of the button
-        QPoint screenBottomRight = qApp->desktop()->screenGeometry().bottomRight();
+        QPoint screenBottomRight = QGuiApplication::primaryScreen()->availableGeometry().bottomRight();
 
         // Set popup menu coordinates which fit on screen.
         if (mainWin()->toolBarArea(toolBar) == Qt::LeftToolBarArea) {


### PR DESCRIPTION
I used the hints given by the deprecation warning messages most of the times, besides qApp->desktop()->screenGeometry().
Also look at the QColorDialog::getRgba fixes: Do you really want the Alpha Channel?