### PR TITLE
UI: Use double click to enter lyrics/chord mode

### DIFF
--- a/src/layout/drawablechordname.cpp
+++ b/src/layout/drawablechordname.cpp
@@ -1,5 +1,5 @@
 /*!
-	Copyright (c) 2019, Matevž Jekovec, Canorus development team
+	Copyright (c) 2019-2022, Matevž Jekovec, Canorus development team
 	All Rights Reserved. See AUTHORS for a complete list of authors.
 
 	Licensed under the GNU GENERAL PUBLIC LICENSE. See LICENSE.GPL for details.
@@ -86,7 +86,7 @@ QString CADrawableChordName::drawableDiatonicPitch()
 {
     QString chordPitch = CADiatonicPitch::diatonicPitchToString(chordName()->diatonicPitch());
     if (chordPitch.isEmpty()) {
-        return "";
+        return CADrawableMusElement::EMPTY_PLACEHOLDER;
     }
 
     chordPitch = chordPitch[0].toUpper(); // chord-style pitch is upper case

--- a/src/layout/drawablemuselement.cpp
+++ b/src/layout/drawablemuselement.cpp
@@ -1,11 +1,13 @@
 /*!
-	Copyright (c) 2006-2009, Matevž Jekovec, Canorus development team
+	Copyright (c) 2006-2022, Matevž Jekovec, Canorus development team
 	All Rights Reserved. See AUTHORS for a complete list of authors.
 
 	Licensed under the GNU GENERAL PUBLIC LICENSE. See COPYING for details.
 */
 
 #include "layout/drawablemuselement.h"
+
+const QString CADrawableMusElement::EMPTY_PLACEHOLDER = "·";
 
 CADrawableMusElement::CADrawableMusElement(CAMusElement* m, CADrawableContext* drawableContext, double x, double y)
     : CADrawable(x, y)

--- a/src/layout/drawablemuselement.h
+++ b/src/layout/drawablemuselement.h
@@ -43,6 +43,8 @@ public:
     virtual CADrawable* clone() { return clone(nullptr); }
     virtual CADrawableMusElement* clone(CADrawableContext* newContext = nullptr) = 0;
 
+    static const QString EMPTY_PLACEHOLDER;
+
 protected:
     void setDrawableMusElementType(CADrawableMusElementType t) { _drawableMusElementType = t; }
 

--- a/src/layout/drawablesyllable.cpp
+++ b/src/layout/drawablesyllable.cpp
@@ -1,5 +1,5 @@
 /*!
-	Copyright (c) 2007, Matevž Jekovec, Canorus development team
+	Copyright (c) 2007-2022, Matevž Jekovec, Canorus development team
 	All Rights Reserved. See AUTHORS for a complete list of authors.
 
 	Licensed under the GNU GENERAL PUBLIC LICENSE. See LICENSE.GPL for details.
@@ -46,18 +46,27 @@ void CADrawableSyllable::draw(QPainter* p, const CADrawSettings s)
     QFont font("Century Schoolbook L");
     font.setPixelSize(qRound(DEFAULT_TEXT_SIZE * s.z));
     p->setFont(font);
-    p->drawText(s.x, s.y + qRound(height() * s.z), textToDrawableText(syllable()->text()));
+
+    QString text = syllable()->text();
+    // Show "space" dot when selected, if empty and not part of hyphen/melisma.
+    if (text.isEmpty() && !syllable()->hyphenStart() && !syllable()->melismaStart()) {
+        text = CADrawableMusElement::EMPTY_PLACEHOLDER;
+    }
+    // Strip melisma.
+    text = textToDrawableText(text);
+
+    p->drawText(s.x, s.y + qRound(height() * s.z), text);
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-    int textWidth = QFontMetrics(font).horizontalAdvance(textToDrawableText(syllable()->text()));
+    int textWidth = QFontMetrics(font).horizontalAdvance(text);
 #else
-    int textWidth = QFontMetrics(font).width(textToDrawableText(syllable()->text()));
+    int textWidth = QFontMetrics(font).width(text);
 #endif
     if (syllable()->hyphenStart() && (width() * s.z - textWidth) > qRound(DEFAULT_DASH_LENGTH * s.z)) {
         p->drawLine(qRound(s.x + width() * s.z * 0.5 + 0.5 * textWidth - 0.5 * s.z * DEFAULT_DASH_LENGTH), s.y + qRound(height() * s.z * 0.7),
             qRound(s.x + width() * s.z * 0.5 + 0.5 * textWidth + 0.5 * s.z * DEFAULT_DASH_LENGTH), s.y + qRound(height() * s.z * 0.7));
     } else if (syllable()->melismaStart() && (width() * s.z - textWidth) > qRound(DEFAULT_DASH_LENGTH * s.z)) {
-        p->drawLine(s.x + textWidth, s.y + qRound(height() * s.z),
+        p->drawLine(s.x + textWidth + (!text.isEmpty()?1.5*s.z:0), s.y + qRound(height() * s.z),
             qRound(s.x + width() * s.z), s.y + qRound(height() * s.z));
     }
 }

--- a/src/ui/mainwin.cpp
+++ b/src/ui/mainwin.cpp
@@ -1,5 +1,5 @@
 /*!
-	Copyright (c) 2006-2020, Reinhard Katzmann, Matevž Jekovec, Canorus development team
+	Copyright (c) 2006-2022, Reinhard Katzmann, Matevž Jekovec, Canorus development team
 	All Rights Reserved. See AUTHORS for a complete list of authors.
 
 	Licensed under the GNU GENERAL PUBLIC LICENSE. See COPYING for details.
@@ -2028,8 +2028,22 @@ void CAMainWin::scoreViewMouseMove(QMouseEvent* e, QPoint coords)
 void CAMainWin::scoreViewDoubleClick(QMouseEvent*, const QPoint)
 {
     if (mode() == EditMode) {
-        static_cast<CAScoreView*>(sender())->selectAllCurBar();
-        static_cast<CAScoreView*>(sender())->repaint();
+        CAScoreView* c = static_cast<CAScoreView*>(sender());
+        CADrawableMusElement* dElt = nullptr;
+        CAMusElement* elt = nullptr;
+
+        if (c->selection().size() == 1) {
+           dElt = c->selection().front();
+           elt = dElt->musElement();
+        }
+
+        if (elt && (elt->musElementType() == CAMusElement::Syllable || elt->musElementType() == CAMusElement::ChordName || (elt->musElementType() == CAMusElement::Mark && (static_cast<CAMark*>(elt)->markType() == CAMark::Text || static_cast<CAMark*>(elt)->markType() == CAMark::BookMark)))) {
+           c->createTextEdit(dElt);
+        } else {
+            c->selectAllCurBar();
+        }
+
+        c->repaint();
     }
 }
 
@@ -2100,10 +2114,6 @@ void CAMainWin::scoreViewMouseRelease(QMouseEvent* e, QPoint coords)
             if (v->selection().size() == 1) {
                 dElt = v->selection().front();
                 elt = dElt->musElement();
-            }
-
-            if (elt && (elt->musElementType() == CAMusElement::Syllable || elt->musElementType() == CAMusElement::ChordName || (elt->musElementType() == CAMusElement::Mark && (static_cast<CAMark*>(elt)->markType() == CAMark::Text || static_cast<CAMark*>(elt)->markType() == CAMark::BookMark)))) {
-                v->createTextEdit(dElt);
             }
         }
         v->repaint();


### PR DESCRIPTION
This PR changes the following:
- Single click now selects syllable, chord, text or bookmark instead of immediately showing the edit text widget.
- Double click on a syllable or a chord now shows the edit text widget.
- Shows · symbol for syllables and chords with no value set for easier selection.