### PR TITLE
chordname: Del clears the chordname, shift+del removes it

### DIFF
--- a/src/score/chordname.cpp
+++ b/src/score/chordname.cpp
@@ -28,6 +28,17 @@ CAChordName::~CAChordName()
 {
 }
 
+/*!
+    Clears the pitch and modifier.
+    This function is usually called when deleting the chord name from the UI, where it shouldn't actually
+    be removed, but only cleared.
+*/
+void CAChordName::clear()
+{
+    setDiatonicPitch(CADiatonicPitch::Undefined);
+    setQualityModifier("");
+}
+
 CAChordName* CAChordName::clone(CAContext* context)
 {
     if (context && context->contextType() != CAContext::ChordNameContext) {

--- a/src/score/chordname.h
+++ b/src/score/chordname.h
@@ -18,6 +18,7 @@ class CAChordName : public CAMusElement {
 public:
     CAChordName(CADiatonicPitch pitch, QString qualityModifier, CAChordNameContext* parent, int timeStart, int timeLength);
     virtual ~CAChordName();
+    void clear();
 
     CAChordName& operator+=(CAInterval);
 

--- a/src/ui/mainwin.cpp
+++ b/src/ui/mainwin.cpp
@@ -5527,12 +5527,12 @@ void CAMainWin::copySelection(CAScoreView* v)
 }
 
 /*!
-	Delete action.
+    Delete action.
 
-	If \a deleteSyllables or \a deleteNotes is True, it completely removes the element.
-	Otherwise it only replaces it with rest.
+    If \a deleteSyllables or \a deleteNotes is True, it completely removes the element (shift+del).
+    Otherwise it only replaces it with rest (del).
 
-	If \a doUndo is True, it also creates undo. doUndo should be False when cutting.
+    If \a doUndo is True, it also creates undo. doUndo should be False when cutting.
 */
 void CAMainWin::deleteSelection(CAScoreView* v, bool deleteSyllables, bool deleteNotes, bool doUndo)
 {
@@ -5715,6 +5715,14 @@ void CAMainWin::deleteSelection(CAScoreView* v, bool deleteSyllables, bool delet
                     lc->repositSyllables();
                 } else {
                     static_cast<CASyllable*>(*i)->clear(); // only clears syllable's text
+                }
+            } else if ((*i)->musElementType() == CAMusElement::ChordName) {
+                if (deleteSyllables) {
+                    CAChordNameContext* cc = static_cast<CAChordNameContext*>((*i)->context());
+                    (*i)->context()->remove(*i); // actually removes the chord if SHIFT is pressed
+                    cc->repositChordNames();
+                } else {
+                    static_cast<CAChordName*>(*i)->clear(); // only clears the chord pitch/modifiers
                 }
             } else if ((*i)->musElementType() == CAMusElement::FiguredBassMark) {
                 CAFiguredBassMark* fbm = static_cast<CAFiguredBassMark*>(*i);


### PR DESCRIPTION
Mimic the behavior from syllables, function marks and figured bass marks.

Part of #84.