### PR TITLE
python 3.9 fixes

### DIFF
--- a/src/canorus.cpp
+++ b/src/canorus.cpp
@@ -74,6 +74,9 @@ void CACanorus::initSearchPaths()
         if (cat == "fonts" && QDir(qApp->applicationDirPath() + "/../../src/fonts/").exists()) {
             QDir::addSearchPath(cat, qApp->applicationDirPath() + "/../../src/fonts/");
         }
+        if (cat == "scripts" && QDir(qApp->applicationDirPath() + "/../../src/scripts/").exists()) {
+            QDir::addSearchPath(cat, qApp->applicationDirPath() + "/../../src/scripts/");
+        }
         if (cat == "doc" && QDir(qApp->applicationDirPath()).exists("/../../doc/")) {
             QDir::addSearchPath(cat, qApp->applicationDirPath() + "/../../doc");
         }

--- a/src/scripting/swigpython.cpp
+++ b/src/scripting/swigpython.cpp
@@ -78,6 +78,9 @@ void CASwigPython::init()
     }
 #endif
 
+    // Load proxy classes.
+    PyRun_SimpleString("import CanorusPython");
+
     mainThreadState = PyThreadState_Get();
     PyEval_ReleaseThread(mainThreadState);
 
@@ -126,6 +129,8 @@ PyObject* CASwigPython::callFunction(QString fileName, QString function, QList<P
         return args.first();
     }
 
+    PyEval_RestoreThread(mainThreadState);
+
     PyObject* pyArgs = PyTuple_New(args.size());
     if (!pyArgs)
         return nullptr;
@@ -135,8 +140,6 @@ PyObject* CASwigPython::callFunction(QString fileName, QString function, QList<P
     // Load module, if not yet
     QString moduleName = fileName.left(fileName.lastIndexOf(".py"));
     moduleName = moduleName.remove(0, moduleName.lastIndexOf("/") + 1);
-
-    PyEval_RestoreThread(CASwigPython::mainThreadState);
 
     PyObject* pyModule;
     if (autoReload) {

--- a/src/widgets/pyconsole.cpp
+++ b/src/widgets/pyconsole.cpp
@@ -558,8 +558,8 @@ bool CAPyConsole::cmdIntern(QString strCmd)
             curObject = curObject->parent();
         PyEval_RestoreThread(CASwigPython::mainThreadState);
         argsPython << CASwigPython::toPythonObject(static_cast<CAMainWin*>(curObject)->document(), CASwigPython::Document);
-        PyEval_ReleaseThread(CASwigPython::mainThreadState);
         argsPython << PyUnicode_FromString(strCmd.toStdString().c_str());
+        PyEval_ReleaseThread(CASwigPython::mainThreadState);
 
         // Can't autoreload because we are using global objects in pycl2.py that would get overwritten.
         auto ret = CASwigPython::callFunction(QFileInfo("scripts:pycl2.py").absoluteFilePath(), "main", argsPython, false);


### PR DESCRIPTION
Fixes behavior change of libpython 3.9+ which caused crash on startup (e.g. on Ubuntu 22.04 using python 3.10.6).