### PR TITLE
mainwinprogressctl: Mainwin should not be owned by progressctl

### DIFF
--- a/src/control/mainwinprogressctl.cpp
+++ b/src/control/mainwinprogressctl.cpp
@@ -66,7 +66,7 @@ void CAMainWinProgressCtl::startProgress(CAFile &f)
 
     connect(_updateTimer.get(), SIGNAL(timeout()), this, SLOT(on_updateTimer_timeout()));
 
-    _bar = std::make_unique<CAProgressStatusBar>(new CAProgressStatusBar(_mainWin.get()));
+    _bar = std::make_unique<CAProgressStatusBar>(new CAProgressStatusBar(_mainWin));
     _mainWin->statusBar()->addWidget(_bar.get());
     connect(_bar.get(), SIGNAL(cancelButtonClicked(bool)), this, SLOT(on_cancelButton_clicked(bool)));
 

--- a/src/control/mainwinprogressctl.h
+++ b/src/control/mainwinprogressctl.h
@@ -32,7 +32,7 @@ private slots:
 private:
     void restoreStatusBar();
 
-    std::unique_ptr<CAMainWin> _mainWin;
+    CAMainWin* _mainWin;
     std::unique_ptr<CAProgressStatusBar> _bar;
     std::unique_ptr<QTimer> _updateTimer;
     CAFile *_file;


### PR DESCRIPTION
Fixes crash on shutting down Canorus due to recursive destructor call (destruct mainwin -> delete progressctl -> wants to delete mainwin again).